### PR TITLE
location replace for grid searches

### DIFF
--- a/src/common/grid/grid-directive.js
+++ b/src/common/grid/grid-directive.js
@@ -56,10 +56,12 @@ angular.module('grid.gridDirective', [])
 
                         if ($scope.grid.bindToState && $scope.grid.search) {
                             $location.search('cSearch', $scope.grid.search);
+                            $location.replace();
                         }
 
                         if ($scope.grid.bindToState) {
                             $location.search(params);
+                            $location.replace();
                         }
 
 


### PR DESCRIPTION
Pretty sure that this can be replaced since it was part of the url fix strategy that we strayed away from.