### PR TITLE
Fixed the max grid width.

### DIFF
--- a/src/common/grid/grid-styles.less
+++ b/src/common/grid/grid-styles.less
@@ -26,7 +26,7 @@
             display: block;
             overflow: hidden;
             text-overflow: ellipsis;
-            max-width: 300px;
+            max-width: 1000px;
             margin-right: auto;
             margin-left: auto;
         }


### PR DESCRIPTION
We were running into issues where the default grid width was not sufficient to see everything that the user needs to see.

The clearest example of this is when you are trying to place a sample and you are only able to see 300 chars of the sample's path... Need to be able to see the full thing in order to make a decision about where you are going to place it.