### PR TITLE
There was a small bug where sdm was used to refer to the sdm in one of its own functions

### DIFF
--- a/src/common/storage/storage-division-manager.js
+++ b/src/common/storage/storage-division-manager.js
@@ -332,7 +332,7 @@ angular.module('storage.storageDivisionManager', [])
 
                 openSampleStorageLinkModal: function () {
 
-                    if (this.selectedCount != 1 || sdm.selectedEmptyCount != 1) {
+                    if (this.selectedCount != 1 || this.selectedEmptyCount != 1) {
                         return;
                     }
 


### PR DESCRIPTION
There was a small bug where sdm was used to refer to the sdm in one of its own functions